### PR TITLE
provide Markdown convenience

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,12 @@
+<!--prettier-ignore-start-->
+[Angular commit format]: https://gist.github.com/brianclements/841ea7bffdb01346392c#type
+<!--prettier-ignore-end-->
+
+> ## Checklist for contributing
+>
+> - [ ] refer to a valid ticket id in the PR title (if applicable)
+> - [ ] use proper [Angular commit format] for semantic release
+> - [ ] provide a brief summary for the proposed changes here,
+>       to a failing service
+
+## Summary

--- a/md/md.go
+++ b/md/md.go
@@ -1,0 +1,20 @@
+package md
+
+import "fmt"
+
+const (
+	// ExampleURL indicates the default value used when an URL is not explicitly defined
+	ExampleURL = "http://example.com"
+)
+
+// MakeLink produces a link in proper Markdown syntax
+func MakeLink(url string, caption string) string {
+	if url == "" {
+		url = ExampleURL
+	}
+	if caption == "" {
+		return url
+	}
+
+	return fmt.Sprintf("[%s](%s)", caption, url)
+}

--- a/md/md_test.go
+++ b/md/md_test.go
@@ -1,0 +1,29 @@
+package md_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ITler/go-lib/md"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeLink(t *testing.T) {
+	testCases := []struct {
+		url     string
+		caption string
+		want    string
+	}{
+		{
+			want: fmt.Sprintf("%s", md.ExampleURL),
+		},
+		{
+			caption: "example",
+			want:    fmt.Sprintf("[%s](%s)", "example", md.ExampleURL),
+		},
+	}
+	for _, tc := range testCases {
+		got := md.MakeLink(tc.url, tc.caption)
+		assert.Equal(t, tc.want, got)
+	}
+}


### PR DESCRIPTION
Adding a module to hold convenience functionality around Markdown (rendering)
* provide a function that makes a markdown link based on a provided URL and caption