### PR TITLE
build: force run go mod tidy after updating deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,5 +19,8 @@
     "automerge": true,
     "automergeType": "pr",
     "platformAutomerge": true
+  },
+  "postUpdateOptions": {
+    "gomodTidy": true
   }
 }


### PR DESCRIPTION
<!--prettier-ignore-start-->
[Angular commit format]: https://gist.github.com/brianclements/841ea7bffdb01346392c#type
<!--prettier-ignore-end-->

> ## Checklist for contributing
>
> - [ ] refer to a valid ticket id in the PR title (if applicable)
> - [x] use proper [Angular commit format] for semantic release
> - [x] provide a brief summary for the proposed changes here,
>       to a failing service

## Summary

Force renovate bot to run `go mod tidy` after updating go dependencies as it seems that the go.sum does not get updated, automatically, although [official docs](https://docs.renovatebot.com/golang/) state it would happen.